### PR TITLE
Meson build issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ install-sh
 cmake-build-debug/
 arctracker-*.tar.gz
 bin/
-CMakeLists.txt
+# CMakeLists.txt
 .DS_Store
 p.patch
 logs

--- a/arctracker-engine/src/audio/mix.c
+++ b/arctracker-engine/src/audio/mix.c
@@ -1,6 +1,7 @@
 #include "mix.h"
 #include "memory/heap.h"
 #include <stdatomic.h>
+#include <stdint.h>
 
 static void atomic_peak_max(atomic_uint *peak, float value);
 

--- a/arctracker-engine/src/audio_api/api_portaudio.c
+++ b/arctracker-engine/src/audio_api/api_portaudio.c
@@ -1,6 +1,7 @@
 #include "api_portaudio.h"
 #include <portaudio.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/arctracker-engine/src/console_ui.c
+++ b/arctracker-engine/src/console_ui.c
@@ -110,7 +110,7 @@ static void render_ui(ui_transport_state_t ui_state, ui_module_info_t module_inf
             "%s %c%c%X%X | ",
             NOTES[event.note],
             ALPHANUM[event.sample_no],
-            event.effects[0].effect_code == 0 ? '-' : event.effects[0].effect_code,
+            (event.effects[0].effect_code[0] == 0 && event.effects[0].effect_code[1] == 0) ? '-' : ALPHANUM[event.effects[0].effect_code[1] + 1],
             event.effects[0].effect_data[0],
             event.effects[0].effect_data[1]);
     }

--- a/arctracker-engine/src/memory/heap.c
+++ b/arctracker-engine/src/memory/heap.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include "heap.h"
 #include "io/error.h"
 #include "messages.h"

--- a/arctracker-engine/src/player/player_cmd_queue.h
+++ b/arctracker-engine/src/player/player_cmd_queue.h
@@ -3,7 +3,7 @@
 
 #include <stdatomic.h>
 #include <stdbool.h>
-#include <sys/_pthread/_pthread_mutex_t.h>
+#include <pthread.h>
 #include "player_command.h"
 
 #define CMD_QUEUE_SIZE 64

--- a/arctracker-engine/subprojects/portaudio-19.7.0/CMakeLists.txt
+++ b/arctracker-engine/subprojects/portaudio-19.7.0/CMakeLists.txt
@@ -1,0 +1,487 @@
+# $Id: $
+#
+# For a "How-To" please refer to the Portaudio documentation at:
+# http://www.portaudio.com/trac/wiki/TutorialDir/Compile/CMake
+#
+
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+
+# Check if the user is building PortAudio stand-alone or as part of a larger
+# project. If this is part of a larger project (i.e. the CMakeLists.txt has
+# been imported by some other CMakeLists.txt), we don't want to trump over
+# the top of that project's global settings.
+IF(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_LIST_DIR})
+  PROJECT(portaudio)
+
+  # CMAKE_CONFIGURATION_TYPES only exists for multi-config generators (like
+  # Visual Studio or Xcode). For these projects, we won't define
+  # CMAKE_BUILD_TYPE as it does not make sense.
+  IF(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    MESSAGE(STATUS "Setting CMAKE_BUILD_TYPE type to 'Debug' as none was specified.")
+    SET(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build." FORCE)
+    SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
+  ENDIF()
+
+  SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+
+  IF(WIN32 AND MSVC)
+    OPTION(PA_DLL_LINK_WITH_STATIC_RUNTIME "Link with static runtime libraries (minimizes runtime dependencies)" ON)
+    IF(PA_DLL_LINK_WITH_STATIC_RUNTIME)
+      FOREACH(flag_var
+        CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+        CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+        IF(${flag_var} MATCHES "/MD")
+          STRING(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+        ENDIF()
+      ENDFOREACH()
+    ENDIF()
+  ENDIF()
+ENDIF()
+
+SET(PA_VERSION 19)
+SET(PA_PKGCONFIG_VERSION ${PA_VERSION})
+SET(PA_SOVERSION "${PA_VERSION}.0")
+
+# Most of the code from this point onwards is related to populating the
+# following variables:
+#   PA_PUBLIC_INCLUDES - This contains the list of public PortAudio header
+#       files. These files will be copied into /include paths on Unix'y
+#       systems when "make install" is invoked.
+#   PA_PRIVATE_INCLUDES - This contains the list of header files which
+#       are not part of PortAudio, but are required by the various hostapis.
+#       It is only used by CMake IDE generators (like Visual Studio) to
+#       provide quick-links to useful headers. It has no impact on build
+#       output.
+#   PA_PRIVATE_INCLUDE_PATHS - This contains the list of include paths which
+#       will be passed to the compiler while PortAudio is being built which
+#       are not required by applications using the PortAudio API.
+#   PA_PRIVATE_COMPILE_DEFINITIONS - This contains a list of preprocessor
+#       macro definitions which will be set when compiling PortAudio source
+#       files.
+#   PA_SOURCES - This contains the list of source files which will be built
+#       into the static and shared PortAudio libraries.
+#   PA_NON_UNICODE_SOURCES - This also contains a list of source files which
+#       will be build into the static and shared PortAudio libraries. However,
+#       these sources will not have any unicode compiler definitions added
+#       to them. This list should only contain external source dependencies.
+#   PA_EXTRA_SHARED_SOURCES - Contains a list of extra files which will be
+#       associated only with the shared PortAudio library. This only seems
+#       relevant for Windows shared libraries which require a list of export
+#       symbols.
+# Where other PA_* variables are set, these are almost always only used to
+# preserve the historic SOURCE_GROUP behavior (which again only has an impact
+# on IDE-style generators for visual appearance) or store the output of
+# find_library() calls.
+
+SET(PA_COMMON_INCLUDES
+  src/common/pa_allocation.h
+  src/common/pa_converters.h
+  src/common/pa_cpuload.h
+  src/common/pa_debugprint.h
+  src/common/pa_dither.h
+  src/common/pa_endianness.h
+  src/common/pa_hostapi.h
+  src/common/pa_memorybarrier.h
+  src/common/pa_process.h
+  src/common/pa_ringbuffer.h
+  src/common/pa_stream.h
+  src/common/pa_trace.h
+  src/common/pa_types.h
+  src/common/pa_util.h
+)
+
+SET(PA_COMMON_SOURCES
+  src/common/pa_allocation.c
+  src/common/pa_converters.c
+  src/common/pa_cpuload.c
+  src/common/pa_debugprint.c
+  src/common/pa_dither.c
+  src/common/pa_front.c
+  src/common/pa_process.c
+  src/common/pa_ringbuffer.c
+  src/common/pa_stream.c
+  src/common/pa_trace.c
+)
+
+SOURCE_GROUP("common" FILES ${PA_COMMON_INCLUDES} ${PA_COMMON_SOURCES})
+
+SET(PA_PUBLIC_INCLUDES include/portaudio.h)
+
+SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake_support)
+
+SET(PA_SKELETON_SOURCES src/hostapi/skeleton/pa_hostapi_skeleton.c)
+SOURCE_GROUP("hostapi\\skeleton" ${PA_SKELETON_SOURCES})
+SET(PA_SOURCES ${PA_COMMON_SOURCES} ${PA_SKELETON_SOURCES})
+SET(PA_PRIVATE_INCLUDE_PATHS src/common ${CMAKE_CURRENT_BINARY_DIR})
+
+IF(WIN32)
+  SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} _CRT_SECURE_NO_WARNINGS)
+
+  SET(PA_PLATFORM_SOURCES
+    src/os/win/pa_win_hostapis.c
+    src/os/win/pa_win_util.c
+    src/os/win/pa_win_waveformat.c
+    src/os/win/pa_win_wdmks_utils.c
+    src/os/win/pa_win_coinitialize.c)
+  SET(PA_PLATFORM_INCLUDES
+    src/os/win/pa_win_coinitialize.h
+    src/os/win/pa_win_wdmks_utils.h)
+
+  IF(MSVC)
+    SET(PA_PLATFORM_SOURCES ${PA_PLATFORM_SOURCES} src/os/win/pa_x86_plain_converters.c)
+    SET(PA_PLATFORM_INCLUDES ${PA_PLATFORM_INCLUDES} src/os/win/pa_x86_plain_converters.h)
+  ELSE()
+    SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} _WIN32_WINNT=0x0501 WINVER=0x0501)
+    SET(DEF_EXCLUDE_X86_PLAIN_CONVERTERS ";")
+  ENDIF()
+
+  SOURCE_GROUP("os\\win" FILES ${PA_PLATFORM_SOURCES} ${PA_PLATFORM_INCLUDES})
+  SET(PA_SOURCES ${PA_SOURCES} ${PA_PLATFORM_SOURCES})
+  SET(PA_PRIVATE_INCLUDES ${PA_PRIVATE_INCLUDES} ${PA_PLATFORM_INCLUDES})
+  SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} src/os/win)
+
+  SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} winmm)
+
+  # Try to find ASIO SDK (assumes that portaudio and asiosdk folders are side-by-side, see
+  # http://www.portaudio.com/trac/wiki/TutorialDir/Compile/WindowsASIOMSVC)
+  FIND_PACKAGE(ASIOSDK)
+  IF(ASIOSDK_FOUND)
+    OPTION(PA_USE_ASIO "Enable support for ASIO" ON)
+  ELSE()
+    OPTION(PA_USE_ASIO "Enable support for ASIO" OFF)
+  ENDIF()
+  IF(PA_USE_ASIO)
+    SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/common)
+    SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host)
+    SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host/pc)
+    SET(PA_ASIO_SOURCES src/hostapi/asio/pa_asio.cpp src/hostapi/asio/iasiothiscallresolver.cpp)
+    SET(PA_ASIOSDK_SOURCES ${ASIOSDK_ROOT_DIR}/common/asio.cpp ${ASIOSDK_ROOT_DIR}/host/pc/asiolist.cpp ${ASIOSDK_ROOT_DIR}/host/asiodrivers.cpp)
+    SOURCE_GROUP("hostapi\\ASIO" FILES ${PA_ASIO_SOURCES})
+    SOURCE_GROUP("hostapi\\ASIO\\ASIOSDK" FILES ${PA_ASIOSDK_SOURCES})
+    SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_asio.h)
+    SET(PA_SOURCES ${PA_SOURCES} ${PA_ASIO_SOURCES})
+    SET(PA_NON_UNICODE_SOURCES ${PA_NON_UNICODE_SOURCES} ${PA_ASIOSDK_SOURCES})
+    SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ole32 uuid)
+  ELSE()
+    # Set variables for DEF file expansion
+    SET(DEF_EXCLUDE_ASIO_SYMBOLS ";")
+  ENDIF()
+
+  OPTION(PA_USE_DS "Enable support for DirectSound" ON)
+  IF(PA_USE_DS)
+    IF(MINGW)
+      MESSAGE(STATUS "DirectSound support will be built with DSound provided by MinGW.")
+      OPTION(PA_USE_DIRECTSOUNDFULLDUPLEXCREATE "Use DirectSound full duplex create" OFF)
+    ELSE(MINGW)
+      OPTION(PA_USE_DIRECTSOUNDFULLDUPLEXCREATE "Use DirectSound full duplex create" ON)
+    ENDIF(MINGW)
+    MARK_AS_ADVANCED(PA_USE_DIRECTSOUNDFULLDUPLEXCREATE)
+    IF(PA_USE_DIRECTSOUNDFULLDUPLEXCREATE)
+      SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PAWIN_USE_DIRECTSOUNDFULLDUPLEXCREATE)
+    ENDIF()
+    SET(PA_DS_INCLUDES src/hostapi/dsound/pa_win_ds_dynlink.h)
+    SET(PA_DS_SOURCES src/hostapi/dsound/pa_win_ds.c src/hostapi/dsound/pa_win_ds_dynlink.c)
+    SOURCE_GROUP("hostapi\\dsound" FILES ${PA_DS_INCLUDES} ${PA_DS_SOURCES})
+    SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_win_ds.h include/pa_win_waveformat.h)
+    SET(PA_PRIVATE_INCLUDES ${PA_PRIVATE_INCLUDES} ${PA_DS_INCLUDES})
+    SET(PA_SOURCES ${PA_SOURCES} ${PA_DS_SOURCES})
+    SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} dsound)
+  ENDIF(PA_USE_DS)
+
+  OPTION(PA_USE_WMME "Enable support for MME" ON)
+  IF(PA_USE_WMME)
+    SET(PA_WMME_SOURCES src/hostapi/wmme/pa_win_wmme.c)
+    SOURCE_GROUP("hostapi\\wmme" FILES ${PA_WMME_SOURCES})
+    SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_win_wmme.h include/pa_win_waveformat.h)
+    SET(PA_SOURCES ${PA_SOURCES} ${PA_WMME_SOURCES})
+    SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ole32 uuid)
+  ENDIF()
+
+  # MinGW versions below 4.93, especially non MinGW-w64 distributions may
+  # break in the wasapi build. If an older MinGW version is required, WASAPI-
+  # support needs to be disabled.
+  OPTION(PA_USE_WASAPI "Enable support for WASAPI" ON)
+  IF(PA_USE_WASAPI)
+    SET(PA_WASAPI_SOURCES src/hostapi/wasapi/pa_win_wasapi.c)
+    SOURCE_GROUP("hostapi\\wasapi" FILES ${PA_WASAPI_SOURCES})
+    SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_win_wasapi.h include/pa_win_waveformat.h)
+    SET(PA_SOURCES ${PA_SOURCES} ${PA_WASAPI_SOURCES})
+    SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ole32 uuid)
+  ELSE()
+    SET(DEF_EXCLUDE_WASAPI_SYMBOLS ";")
+  ENDIF()
+
+  OPTION(PA_USE_WDMKS "Enable support for WDMKS" ON)
+  IF(PA_USE_WDMKS)
+    SET(PA_WDMKS_SOURCES src/hostapi/wdmks/pa_win_wdmks.c)
+    SOURCE_GROUP("hostapi\\wdmks" FILES ${PA_WDMKS_SOURCES})
+    SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_win_wdmks.h)
+    SET(PA_SOURCES ${PA_SOURCES} ${PA_WDMKS_SOURCES})
+    SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} setupapi ole32 uuid)
+  ENDIF()
+
+  OPTION(PA_USE_WDMKS_DEVICE_INFO "Use WDM/KS API for device info" ON)
+  MARK_AS_ADVANCED(PA_USE_WDMKS_DEVICE_INFO)
+  IF(PA_USE_WDMKS_DEVICE_INFO)
+    SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PAWIN_USE_WDMKS_DEVICE_INFO)
+  ENDIF()
+
+  SET(GENERATED_MESSAGE "CMake generated file, do NOT edit! Use CMake-GUI to change configuration instead.")
+  CONFIGURE_FILE(cmake_support/template_portaudio.def ${CMAKE_CURRENT_BINARY_DIR}/portaudio_cmake.def @ONLY)
+  CONFIGURE_FILE(cmake_support/options_cmake.h.in ${CMAKE_CURRENT_BINARY_DIR}/options_cmake.h @ONLY)
+  SET(PA_PRIVATE_INCLUDES ${PA_PRIVATE_INCLUDES} ${CMAKE_CURRENT_BINARY_DIR}/options_cmake.h)
+  SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PORTAUDIO_CMAKE_GENERATED)
+  SOURCE_GROUP("cmake_generated" FILES ${CMAKE_CURRENT_BINARY_DIR}/portaudio_cmake.def ${CMAKE_CURRENT_BINARY_DIR}/options_cmake.h)
+
+  SET(PA_EXTRA_SHARED_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/portaudio_cmake.def)
+
+ELSE()
+
+  SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} src/os/unix)
+  SET(PA_PLATFORM_SOURCES src/os/unix/pa_unix_hostapis.c src/os/unix/pa_unix_util.c)
+  SOURCE_GROUP("os\\unix" FILES ${PA_PLATFORM_SOURCES})
+  SET(PA_SOURCES ${PA_SOURCES} ${PA_PLATFORM_SOURCES})
+
+  IF(APPLE)
+
+    SET(CMAKE_MACOSX_RPATH 1)
+    OPTION(PA_USE_COREAUDIO "Enable support for CoreAudio" ON)
+    IF(PA_USE_COREAUDIO)
+      SET(PA_COREAUDIO_SOURCES
+        src/hostapi/coreaudio/pa_mac_core.c
+        src/hostapi/coreaudio/pa_mac_core_blocking.c
+        src/hostapi/coreaudio/pa_mac_core_utilities.c)
+      SET(PA_COREAUDIO_INCLUDES
+        src/hostapi/coreaudio/pa_mac_core_blocking.h
+        src/hostapi/coreaudio/pa_mac_core_utilities.h)
+      SOURCE_GROUP("hostapi\\coreaudio" FILES ${PA_COREAUDIO_SOURCES} ${PA_COREAUDIO_INCLUDES})
+      SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_mac_core.h)
+      SET(PA_PRIVATE_INCLUDES ${PA_PRIVATE_INCLUDES} ${PA_COREAUDIO_INCLUDES})
+      SET(PA_SOURCES ${PA_SOURCES} ${PA_COREAUDIO_SOURCES})
+
+      FIND_LIBRARY(COREAUDIO_LIBRARY CoreAudio REQUIRED)
+      FIND_LIBRARY(AUDIOTOOLBOX_LIBRARY AudioToolbox REQUIRED)
+      FIND_LIBRARY(AUDIOUNIT_LIBRARY AudioUnit REQUIRED)
+      FIND_LIBRARY(COREFOUNDATION_LIBRARY CoreFoundation REQUIRED)
+      FIND_LIBRARY(CORESERVICES_LIBRARY CoreServices REQUIRED)
+      MARK_AS_ADVANCED(COREAUDIO_LIBRARY AUDIOTOOLBOX_LIBRARY AUDIOUNIT_LIBRARY COREFOUNDATION_LIBRARY CORESERVICES_LIBRARY)
+      SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ${COREAUDIO_LIBRARY} ${AUDIOTOOLBOX_LIBRARY} ${AUDIOUNIT_LIBRARY} ${COREFOUNDATION_LIBRARY} ${CORESERVICES_LIBRARY})
+      SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_USE_COREAUDIO)
+      SET(PA_PKGCONFIG_LDFLAGS "${PA_PKGCONFIG_LDFLAGS} -framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework CoreFoundation -framework CoreServices")
+    ENDIF()
+
+  ELSEIF(UNIX)
+
+    FIND_PACKAGE(Jack)
+    IF(JACK_FOUND)
+      OPTION(PA_USE_JACK "Enable support for Jack" ON)
+    ELSE()
+      OPTION(PA_USE_JACK "Enable support for Jack" OFF)
+    ENDIF()
+    IF(PA_USE_JACK)
+      SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${JACK_INCLUDE_DIRS})
+      SET(PA_JACK_SOURCES src/hostapi/jack/pa_jack.c)
+      SOURCE_GROUP("hostapi\\JACK" FILES ${PA_JACK_SOURCES})
+      SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_jack.h)
+      SET(PA_SOURCES ${PA_SOURCES} ${PA_JACK_SOURCES})
+      SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_USE_JACK)
+      SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ${JACK_LIBRARIES})
+      SET(PA_PKGCONFIG_LDFLAGS "${PA_PKGCONFIG_LDFLAGS} -ljack")
+    ENDIF()
+
+    FIND_PACKAGE(ALSA)
+    IF(ALSA_FOUND)
+      OPTION(PA_USE_ALSA "Enable support for ALSA" ON)
+      OPTION(PA_ALSA_DYNAMIC "Enable loading ALSA through dlopen" OFF)
+    ELSE()
+      OPTION(PA_USE_ALSA "Enable support for ALSA" OFF)
+    ENDIF()
+    IF(PA_USE_ALSA)
+      SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ALSA_INCLUDE_DIRS})
+      SET(PA_ALSA_SOURCES src/hostapi/alsa/pa_linux_alsa.c)
+      SOURCE_GROUP("hostapi\\ALSA" FILES ${PA_ALSA_SOURCES})
+      SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_linux_alsa.h)
+      SET(PA_SOURCES ${PA_SOURCES} ${PA_ALSA_SOURCES})
+      SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_USE_ALSA)
+      IF(PA_ALSA_DYNAMIC)
+        SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_ALSA_DYNAMIC)
+        SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ${CMAKE_DL_LIBS})
+        SET(PA_PKGCONFIG_LDFLAGS "${PA_PKGCONFIG_LDFLAGS} -l${CMAKE_DL_LIBS}")
+      ELSE()
+        SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ${ALSA_LIBRARIES})
+        SET(PA_PKGCONFIG_LDFLAGS "${PA_PKGCONFIG_LDFLAGS} -lasound")
+      ENDIF()
+    ENDIF()
+
+  ENDIF()
+
+  SET(PA_PKGCONFIG_LDFLAGS "${PA_PKGCONFIG_LDFLAGS} -lm -lpthread")
+  SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} m pthread)
+
+ENDIF()
+
+SOURCE_GROUP("include" FILES ${PA_PUBLIC_INCLUDES})
+
+SET(PA_INCLUDES ${PA_PRIVATE_INCLUDES} ${PA_PUBLIC_INCLUDES})
+
+IF(WIN32)
+  OPTION(PA_UNICODE_BUILD "Enable Portaudio Unicode build" ON)
+  IF(PA_UNICODE_BUILD)
+    SET_SOURCE_FILES_PROPERTIES(${PA_SOURCES} PROPERTIES COMPILE_DEFINITIONS "UNICODE;_UNICODE")
+  ENDIF()
+ENDIF()
+
+OPTION(PA_ENABLE_DEBUG_OUTPUT "Enable debug output for Portaudio" OFF)
+IF(PA_ENABLE_DEBUG_OUTPUT)
+  SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_ENABLE_DEBUG_OUTPUT)
+ENDIF()
+
+INCLUDE(TestBigEndian)
+TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
+IF(IS_BIG_ENDIAN)
+  SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_BIG_ENDIAN)
+ELSE()
+  SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_LITTLE_ENDIAN)
+ENDIF()
+
+OPTION(PA_BUILD_STATIC "Build static library" ON)
+OPTION(PA_BUILD_SHARED "Build shared/dynamic library" ON)
+
+IF(MSVC)
+  OPTION(PA_LIBNAME_ADD_SUFFIX "Add suffix _static to static library name" ON)
+ELSE()
+  OPTION(PA_LIBNAME_ADD_SUFFIX "Add suffix _static to static library name" OFF)
+ENDIF()
+
+# MSVC: if PA_LIBNAME_ADD_SUFFIX is not used, and both static and shared libraries are
+# built, one, of import- and static libraries, will overwrite the other. In
+# embedded builds this is not an issue as they will only build the configuration
+# used in the host application.
+MARK_AS_ADVANCED(PA_LIBNAME_ADD_SUFFIX)
+IF(MSVC AND PA_BUILD_STATIC AND PA_BUILD_SHARED AND NOT PA_LIBNAME_ADD_SUFFIX)
+  MESSAGE(WARNING "Building both shared and static libraries, and avoiding the suffix _static will lead to a name conflict")
+  SET(PA_LIBNAME_ADD_SUFFIX ON CACHE BOOL "Forcing use of suffix _static to avoid name conflict between static and import library" FORCE)
+  MESSAGE(WARNING "PA_LIBNAME_ADD_SUFFIX was set to ON")
+ENDIF()
+
+SET(PA_TARGETS "")
+
+IF(PA_BUILD_SHARED)
+  LIST(APPEND PA_TARGETS portaudio)
+  ADD_LIBRARY(portaudio SHARED ${PA_INCLUDES} ${PA_COMMON_INCLUDES} ${PA_SOURCES} ${PA_NON_UNICODE_SOURCES} ${PA_EXTRA_SHARED_SOURCES})
+  SET_PROPERTY(TARGET portaudio APPEND_STRING PROPERTY COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS})
+  TARGET_INCLUDE_DIRECTORIES(portaudio PRIVATE ${PA_PRIVATE_INCLUDE_PATHS})
+  TARGET_INCLUDE_DIRECTORIES(portaudio PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>" "$<INSTALL_INTERFACE:include>")
+  TARGET_LINK_LIBRARIES(portaudio ${PA_LIBRARY_DEPENDENCIES})
+ENDIF()
+
+IF(PA_BUILD_STATIC)
+  LIST(APPEND PA_TARGETS portaudio_static)
+  ADD_LIBRARY(portaudio_static STATIC ${PA_INCLUDES} ${PA_COMMON_INCLUDES} ${PA_SOURCES} ${PA_NON_UNICODE_SOURCES})
+  SET_PROPERTY(TARGET portaudio_static APPEND_STRING PROPERTY COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS})
+  TARGET_INCLUDE_DIRECTORIES(portaudio_static PRIVATE ${PA_PRIVATE_INCLUDE_PATHS})
+  TARGET_INCLUDE_DIRECTORIES(portaudio_static PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>" "$<INSTALL_INTERFACE:include>")
+  TARGET_LINK_LIBRARIES(portaudio_static ${PA_LIBRARY_DEPENDENCIES})
+  IF(NOT PA_LIBNAME_ADD_SUFFIX)
+    SET_PROPERTY(TARGET portaudio_static PROPERTY OUTPUT_NAME portaudio)
+  ENDIF()
+ENDIF()
+
+IF(WIN32 AND MSVC)
+  OPTION(PA_CONFIG_LIB_OUTPUT_PATH "Make sure that output paths are kept neat" OFF)
+  IF(CMAKE_CL_64)
+    SET(TARGET_POSTFIX x64)
+    IF(PA_CONFIG_LIB_OUTPUT_PATH)
+      SET(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin/x64)
+    ENDIF()
+  ELSE()
+    SET(TARGET_POSTFIX x86)
+    IF(PA_CONFIG_LIB_OUTPUT_PATH)
+      SET(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin/Win32)
+    ENDIF()
+  ENDIF()
+  IF(PA_BUILD_SHARED)
+    IF(PA_LIBNAME_ADD_SUFFIX)
+      SET_TARGET_PROPERTIES(portaudio PROPERTIES OUTPUT_NAME portaudio_${TARGET_POSTFIX})
+    ELSE()
+      SET_TARGET_PROPERTIES(portaudio PROPERTIES OUTPUT_NAME portaudio)
+    ENDIF()
+  ENDIF()
+  IF(PA_BUILD_STATIC)
+    IF(PA_LIBNAME_ADD_SUFFIX)
+      SET_TARGET_PROPERTIES(portaudio_static PROPERTIES OUTPUT_NAME portaudio_static_${TARGET_POSTFIX})
+    ELSE()
+      SET_TARGET_PROPERTIES(portaudio_static PROPERTIES OUTPUT_NAME portaudio)
+    ENDIF()
+  ENDIF()
+ELSE()
+  IF(APPLE AND CMAKE_VERSION VERSION_GREATER 3.4.2)
+    OPTION(PA_OUTPUT_OSX_FRAMEWORK "Generate an OS X framework instead of the simple library" OFF)
+    IF(PA_OUTPUT_OSX_FRAMEWORK)
+      SET_TARGET_PROPERTIES(portaudio PROPERTIES
+        FRAMEWORK TRUE
+        MACOSX_FRAMEWORK_IDENTIFIER com.portaudio
+        FRAMEWORK_VERSION A
+        PUBLIC_HEADER "${PA_PUBLIC_INCLUDES}"
+        VERSION ${PA_SOVERSION}
+        SOVERSION ${PA_SOVERSION})
+    ENDIF()
+  ENDIF()
+ENDIF()
+
+# At least on Windows in embedded builds, portaudio's install target should likely
+# not be executed, as the library would usually already be installed as part of, and
+# by means of the host application.
+# The option below offers the option to avoid executing the portaudio install target
+# for cases in which the host-application executes install, but no independent install
+# of portaudio is wished.
+OPTION(PA_DISABLE_INSTALL "Disable targets install and uninstall (for embedded builds)" OFF)
+
+IF(NOT PA_OUTPUT_OSX_FRAMEWORK AND NOT PA_DISABLE_INSTALL)
+  INCLUDE(CMakePackageConfigHelpers)
+
+  CONFIGURE_PACKAGE_CONFIG_FILE(cmake_support/portaudioConfig.cmake.in ${CMAKE_BINARY_DIR}/cmake/portaudio/portaudioConfig.cmake
+    INSTALL_DESTINATION "lib/cmake/portaudio"
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+  WRITE_BASIC_PACKAGE_VERSION_FILE(${CMAKE_BINARY_DIR}/cmake/portaudio/portaudioConfigVersion.cmake
+    VERSION ${PA_VERSION}
+    COMPATIBILITY SameMajorVersion)
+  CONFIGURE_FILE(cmake_support/portaudio-2.0.pc.in ${CMAKE_CURRENT_BINARY_DIR}/portaudio-2.0.pc @ONLY)
+  INSTALL(FILES README.md DESTINATION share/doc/portaudio)
+  INSTALL(FILES LICENSE.txt DESTINATION share/doc/portaudio)
+  INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/portaudio-2.0.pc DESTINATION lib/pkgconfig)
+  INSTALL(FILES ${PA_PUBLIC_INCLUDES} DESTINATION include)
+  INSTALL(TARGETS ${PA_TARGETS}
+    EXPORT portaudio-targets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
+  INSTALL(EXPORT portaudio-targets FILE "portaudioTargets.cmake" DESTINATION "lib/cmake/portaudio")
+  EXPORT(TARGETS ${PA_TARGETS} FILE "${PROJECT_BINARY_DIR}/cmake/portaudio/portaudioTargets.cmake")
+  INSTALL(FILES "${CMAKE_BINARY_DIR}/cmake/portaudio/portaudioConfig.cmake"
+                "${CMAKE_BINARY_DIR}/cmake/portaudio/portaudioConfigVersion.cmake"
+    DESTINATION "lib/cmake/portaudio")
+
+  IF (NOT TARGET uninstall)
+    CONFIGURE_FILE(
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake_support/cmake_uninstall.cmake.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+      IMMEDIATE @ONLY)
+    ADD_CUSTOM_TARGET(uninstall
+      COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+  ENDIF()
+ENDIF()
+
+# Prepared for inclusion of test files
+OPTION(PA_BUILD_TESTS "Include test projects" OFF)
+IF(PA_BUILD_TESTS)
+  SUBDIRS(test)
+ENDIF()
+
+# Prepared for inclusion of test files
+OPTION(PA_BUILD_EXAMPLES "Include example projects" OFF)
+IF(PA_BUILD_EXAMPLES)
+  SUBDIRS(examples)
+ENDIF()

--- a/arctracker-engine/subprojects/rtmidi-6.0.0/CMakeLists.txt
+++ b/arctracker-engine/subprojects/rtmidi-6.0.0/CMakeLists.txt
@@ -1,0 +1,315 @@
+# 2018 (c) Juan G. Victores, Bartek Łukawski, Stephen Sinclair
+# CopyPolicy: RtMidi license.
+
+# Set minimum CMake required version for this project.
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
+
+# Define a C++ project.
+project(RtMidi LANGUAGES CXX C)
+
+# standards version
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Check for Jack (any OS)
+find_library(JACK_LIB jack)
+find_package(PkgConfig)
+pkg_check_modules(jack jack)
+if(JACK_LIB OR jack_FOUND)
+  set(HAVE_JACK TRUE)
+endif()
+
+# Necessary for Windows
+if(WIN32)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+# Standard CMake options
+option(BUILD_SHARED_LIBS "Build as shared library" ON)
+
+if (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebInfo;MinSizeRel")
+endif()
+if(WINDOWS)
+  set(CMAKE_DEBUG_POSTFIX d CACHE STRING "Postfix for debug version of library")
+endif()
+
+# Build Options
+set(RTMIDI_TARGETNAME_UNINSTALL "uninstall" CACHE STRING "Name of 'uninstall' build target")
+
+# API Options
+option(RTMIDI_API_JACK "Compile with JACK support." ${HAVE_JACK})
+option(RTMIDI_API_WINMM "Compile with WINMM support." ${WIN32})
+option(RTMIDI_API_CORE "Compile with CoreMIDI support." ${APPLE})
+option(RTMIDI_API_ALSA "Compile with ALSA support." ${ALSA})
+option(RTMIDI_API_AMIDI "Compile with Android support." ${ANDROID})
+
+# Add -Wall if possible
+if (CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+endif (CMAKE_COMPILER_IS_GNUCXX)
+
+# Add debug flags
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_definitions(-D__RTMIDI_DEBUG__)
+  if (CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  endif (CMAKE_COMPILER_IS_GNUCXX)
+endif ()
+
+# Read libtool version info from configure.ac
+set(R "m4_define\\(\\[lt_([a-z]+)\\], ([0-9]+)\\)")
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/configure.ac" CONFIGAC
+  REGEX ${R})
+foreach(_S ${CONFIGAC})
+  string(REGEX REPLACE ${R} "\\1" k ${_S})
+  string(REGEX REPLACE ${R} "\\2" v ${_S})
+  set(SO_${k} ${v})
+endforeach()
+math(EXPR SO_current_minus_age "${SO_current} - ${SO_age}")
+set(SO_VER "${SO_current_minus_age}")
+set(FULL_VER "${SO_current_minus_age}.${SO_age}.${SO_revision}")
+
+# Read package version info from configure.ac
+set(R "AC_INIT\\(RtMidi, ([0-9\\.]+),.*\\)")
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/configure.ac" CONFIGAC
+  REGEX ${R})
+string(REGEX REPLACE ${R} "\\1" PACKAGE_VERSION ${CONFIGAC})
+
+# Init variables
+set(rtmidi_SOURCES RtMidi.cpp RtMidi.h rtmidi_c.cpp rtmidi_c.h)
+set(LINKLIBS)
+set(PUBLICLINKLIBS)
+set(INCDIRS)
+set(PKGCONFIG_REQUIRES)
+set(LIBS_REQUIRES)
+set(API_DEFS)
+set(API_LIST)
+set(PACKAGE_DEPENDENCIES)
+
+# Tweak API-specific configuration.
+
+# Jack
+if(RTMIDI_API_JACK)
+  if (NOT HAVE_JACK)
+    message(FATAL_ERROR "Jack API requested but no Jack dev libraries found")
+  endif()
+  set(NEED_PTHREAD ON)
+  list(APPEND PKGCONFIG_REQUIRES "jack")
+  list(APPEND API_DEFS "-D__UNIX_JACK__")
+  list(APPEND API_LIST "jack")
+  if(jack_FOUND)
+    list(APPEND LINKLIBS ${jack_LIBRARIES})
+    list(APPEND INCDIRS ${jack_INCLUDEDIR})
+  else()
+    list(APPEND LINKLIBS ${JACK_LIB})
+  endif()
+
+  # Check for jack_port_rename
+  include(CheckSymbolExists)
+  set(tmp_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+  list(APPEND CMAKE_REQUIRED_LIBRARIES jack)
+  check_symbol_exists(jack_port_rename ${jack_INCLUDEDIR}/jack/jack.h JACK_HAS_PORT_RENAME)
+  set(CMAKE_REQUIRED_LIBRARIES ${tmp_CMAKE_REQUIRED_LIBRARIES})
+  if(JACK_HAS_PORT_RENAME)
+    list(APPEND API_DEFS "-DJACK_HAS_PORT_RENAME")
+  endif()
+endif()
+
+# ALSA
+find_package(ALSA)
+if(ALSA_FOUND OR ALSA)
+  set(NEED_PTHREAD ON)
+  list(APPEND INCDIRS ${ALSA_INCLUDE_DIR})
+  list(APPEND LINKLIBS ALSA::ALSA)
+  list(APPEND PKGCONFIG_REQUIRES "alsa")
+  list(APPEND API_DEFS "-D__LINUX_ALSA__")
+  list(APPEND API_LIST "alsa")
+  list(APPEND PACKAGE_DEPENDENCIES "find_dependency(ALSA)")
+endif()
+
+# WinMM
+if(RTMIDI_API_WINMM)
+  list(APPEND API_DEFS "-D__WINDOWS_MM__")
+  list(APPEND API_LIST "winmm")
+  list(APPEND LINKLIBS winmm)
+endif()
+
+# CoreMIDI
+if(RTMIDI_API_CORE)
+  find_library(CORESERVICES_LIB CoreServices)
+  find_library(COREAUDIO_LIB CoreAudio)
+  find_library(COREMIDI_LIB CoreMIDI)
+  find_library(COREFOUNDATION_LIB CoreFoundation)
+  list(APPEND API_DEFS "-D__MACOSX_CORE__")
+  list(APPEND API_LIST "coremidi")
+  list(APPEND LINKLIBS ${CORESERVICES_LIB} ${COREAUDIO_LIB} ${COREMIDI_LIB} ${COREFOUNDATION_LIB})
+  list(APPEND LIBS_REQUIRES "-framework CoreServices -framework CoreAudio -framework CoreMIDI -framework CoreFoundation")
+  list(APPEND LINKFLAGS "-Wl,-F/Library/Frameworks")
+endif()
+
+# Android AMIDI
+if(ANDROID)
+  set(NEED_PTHREAD ON)
+  set(JAVA_INCLUDE_PATH2 NotNeeded)
+  set(JAVA_AWT_INCLUDE_PATH NotNeeded)
+  find_package(JNI)
+#  find_library(ALOG_LIB log android)
+  list(APPEND API_DEFS "-D__AMIDI__")
+  list(APPEND API_LIST "amidi")
+  list(APPEND LINKLIBS log ${JNI_LIBRARIES} amidi)
+endif()
+
+# pthread
+if (NEED_PTHREAD)
+  find_package(Threads REQUIRED
+    CMAKE_THREAD_PREFER_PTHREAD
+    THREADS_PREFER_PTHREAD_FLAG)
+  list(APPEND PUBLICLINKLIBS Threads::Threads)
+  list(APPEND PACKAGE_DEPENDENCIES "find_dependency(Threads)")
+endif()
+
+# Create library targets.
+set(LIB_TARGETS)
+
+# Use RTMIDI_BUILD_SHARED_LIBS / RTMIDI_BUILD_STATIC_LIBS if they
+# are defined, otherwise default to standard BUILD_SHARED_LIBS.
+if (DEFINED RTMIDI_BUILD_SHARED_LIBS AND NOT RTMIDI_BUILD_SHARED_LIBS STREQUAL "")
+  if (RTMIDI_BUILD_SHARED_LIBS)
+    add_library(rtmidi SHARED ${rtmidi_SOURCES})
+  else()
+    add_library(rtmidi STATIC ${rtmidi_SOURCES})
+  endif()
+elseif (DEFINED RTMIDI_BUILD_STATIC_LIBS AND NOT RTMIDI_BUILD_STATIC_LIBS STREQUAL "")
+  if (RTMIDI_BUILD_STATIC_LIBS)
+    add_library(rtmidi STATIC ${rtmidi_SOURCES})
+  else()
+    add_library(rtmidi SHARED ${rtmidi_SOURCES})
+  endif()
+else()
+  add_library(rtmidi ${rtmidi_SOURCES})
+endif()
+list(APPEND LIB_TARGETS rtmidi)
+
+# Add headers destination for install rule.
+set_property(TARGET rtmidi PROPERTY PUBLIC_HEADER RtMidi.h rtmidi_c.h)
+set_target_properties(rtmidi PROPERTIES
+  SOVERSION ${SO_VER}
+  VERSION ${FULL_VER})
+
+# Set standard installation directories.
+include(GNUInstallDirs)
+
+# Set include paths, populate target interface.
+target_include_directories(rtmidi PRIVATE ${INCDIRS}
+                                  PUBLIC
+                                    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+# Set compile-time definitions
+target_compile_definitions(rtmidi PRIVATE ${API_DEFS})
+target_compile_definitions(rtmidi PRIVATE RTMIDI_EXPORT)
+target_link_libraries(rtmidi PUBLIC ${PUBLICLINKLIBS} 
+                             PRIVATE ${LINKLIBS})
+
+# Add tests if requested.
+option(RTMIDI_BUILD_TESTING "Build test programs" ON)
+if (NOT DEFINED RTMIDI_BUILD_TESTING OR RTMIDI_BUILD_TESTING STREQUAL "")
+  set(RTMIDI_BUILD_TESTING ${BUILD_TESTING})
+endif()
+if (RTMIDI_BUILD_TESTING)
+  include(CTest)
+  add_executable(cmidiin    tests/cmidiin.cpp)
+  add_executable(midiclock  tests/midiclock.cpp)
+  add_executable(midiout    tests/midiout.cpp)
+  add_executable(midiprobe  tests/midiprobe.cpp)
+  add_executable(qmidiin    tests/qmidiin.cpp)
+  add_executable(sysextest  tests/sysextest.cpp)
+  add_executable(apinames   tests/apinames.cpp)
+  add_executable(testcapi   tests/testcapi.c)
+  list(GET LIB_TARGETS 0 LIBRTMIDI)
+  set_target_properties(cmidiin midiclock midiout midiprobe qmidiin sysextest apinames testcapi
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY tests
+               INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}
+               LINK_LIBRARIES ${LIBRTMIDI})
+  add_test(NAME apinames COMMAND apinames)
+endif()
+
+# Set standard installation directories.
+include(GNUInstallDirs)
+
+# Message
+string(REPLACE ";" " " apilist "${API_LIST}")
+message(STATUS "Compiling with support for: ${apilist}")
+
+# PkgConfig file
+string(REPLACE ";" " " req "${PKGCONFIG_REQUIRES}")
+string(REPLACE ";" " " req_libs "${LIBS_REQUIRES}")
+string(REPLACE ";" " " api "${API_DEFS}")
+set(prefix ${CMAKE_INSTALL_PREFIX})
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/rtmidi.pc.in" "rtmidi.pc" @ONLY)
+
+# Add install rule.
+install(TARGETS ${LIB_TARGETS}
+        EXPORT RtMidiTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rtmidi)
+
+# Store the package in the user registry.
+export(PACKAGE RtMidi)
+
+# Set installation path for CMake files.
+set(RTMIDI_CMAKE_DESTINATION share/rtmidi)
+
+# Export library target (build-tree).
+export(EXPORT RtMidiTargets
+       NAMESPACE RtMidi::)
+
+# Export library target (install-tree).
+install(EXPORT RtMidiTargets
+        DESTINATION ${RTMIDI_CMAKE_DESTINATION}
+        NAMESPACE RtMidi::)
+
+# Configure uninstall target.
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/RtMidiConfigUninstall.cmake.in"
+    "${CMAKE_BINARY_DIR}/RtMidiConfigUninstall.cmake" @ONLY)
+
+# Create uninstall target.
+add_custom_target(${RTMIDI_TARGETNAME_UNINSTALL}
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/RtMidiConfigUninstall.cmake)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/rtmidi.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+# Set up CMake package
+include(CMakePackageConfigHelpers)
+
+# Write cmake package version file
+write_basic_package_version_file(
+    rtmidi-config-version.cmake
+    VERSION ${FULL_VER}
+    COMPATIBILITY SameMajorVersion
+)
+
+string(REPLACE ";" "\n" package_dependencies "${PACKAGE_DEPENDENCIES}")
+
+# Write cmake package config file
+configure_package_config_file (
+    cmake/rtmidi-config.cmake.in
+    rtmidi-config.cmake
+    INSTALL_DESTINATION "${RTMIDI_CMAKE_DESTINATION}"
+)
+
+# Install package files
+install (
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/rtmidi-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/rtmidi-config-version.cmake"
+    DESTINATION
+        "${RTMIDI_CMAKE_DESTINATION}"
+)

--- a/arctracker-ui/src-tauri/build.rs
+++ b/arctracker-ui/src-tauri/build.rs
@@ -85,6 +85,13 @@ fn main() {
         // RtMidi is implemented in C++.
         println!("cargo:rustc-link-lib=c++");
     }
+    #[cfg(target_os = "linux")]
+    {
+        println!("cargo:rustc-link-lib=dylib=asound");
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+        println!("cargo:rustc-link-lib=dylib=pthread");
+        println!("cargo:rustc-link-lib=dylib=m");
+    }
     println!("cargo:rustc-link-lib=static=arctracker");
     println!("cargo:rerun-if-changed={}", engine_source_directory.join("meson.build").display());
     println!("cargo:rerun-if-changed={}", engine_source_directory.join("src").display());

--- a/arctracker-ui/src/player/player.ts
+++ b/arctracker-ui/src/player/player.ts
@@ -53,35 +53,7 @@ export const player = {
         displayedPatternNo,
         numTracks,
       );
-      useStore.getState().setTransportState({
-        playbackAvailable: snapshot.playbackAvailable,
-        playing: snapshot.playing,
-        looping: snapshot.looping,
-        sequencePos: snapshot.sequencePos,
-        patternIndex: snapshot.patternIndex,
-      });
-      useStore
-        .getState()
-        .setTrackMuteState(snapshot.tracks.map((track) => track.muted));
-      useStore
-        .getState()
-        .setEffectsDisplayed(
-          snapshot.tracks.map((track) => track.effectsDisplayed),
-        );
-      useStore
-        .getState()
-        .setTrackPanning(snapshot.tracks.map((track) => track.panning));
-      if (snapshot.playing && snapshot.newPattern !== null) {
-        useStore.getState().setCurrentPattern({
-          patternNo: snapshot.patternNo,
-          lines: snapshot.newPattern,
-        });
-      }
-      const currentBpm = useStore.getState().module.beatsPerMinute;
-      if (currentBpm !== snapshot.currentBpm) {
-        const linesPerBeat = useStore.getState().module.linesPerBeat;
-        useStore.getState().updateTempo(linesPerBeat, snapshot.currentBpm);
-      }
+      useStore.getState().updatePlaybackState(snapshot);
     } finally {
       snapshotPolling = false;
     }

--- a/arctracker-ui/src/store/useStore.ts
+++ b/arctracker-ui/src/store/useStore.ts
@@ -10,6 +10,7 @@ import { ExportState } from "../audioExport/audioExport.ts";
 import { ModuleTempo } from "../editing/tempo.ts";
 import { DraftAppConfig } from "../config/appConfig.ts";
 import { UserMessage } from "../messages/userMessages.ts";
+import type { PlayerSnapshot } from "../player/player.ts";
 
 interface AppStore {
   moduleId: number;
@@ -66,6 +67,7 @@ interface AppStore {
   setLoadingModule: (loading: boolean) => void;
   logMessage: (message: UserMessage) => void;
   setHexCalculatorActive: (active: boolean) => void;
+  updatePlaybackState: (snapshot: PlayerSnapshot) => void;
 }
 
 const initialModule: Module = {
@@ -392,5 +394,67 @@ export const useStore = create<AppStore>((set) => ({
   setHexCalculatorActive: (hexCalculatorActive: boolean) =>
     set({
       hexCalculatorActive,
+    }),
+
+  updatePlaybackState: (snapshot: PlayerSnapshot) =>
+    set((state) => {
+      const nextState: Partial<AppStore> = {};
+
+      const currentTS = state.transportState;
+      if (
+        currentTS.playbackAvailable !== snapshot.playbackAvailable ||
+        currentTS.playing !== snapshot.playing ||
+        currentTS.looping !== snapshot.looping ||
+        currentTS.sequencePos !== snapshot.sequencePos ||
+        currentTS.patternIndex !== snapshot.patternIndex
+      ) {
+        nextState.transportState = {
+          playbackAvailable: snapshot.playbackAvailable,
+          playing: snapshot.playing,
+          looping: snapshot.looping,
+          sequencePos: snapshot.sequencePos,
+          patternIndex: snapshot.patternIndex,
+        };
+      }
+
+      const nextMutes = snapshot.tracks.map((track) => track.muted);
+      if (!arraysEqual(state.trackMuteState, nextMutes)) {
+        nextState.trackMuteState = nextMutes;
+      }
+
+      const nextEffects = snapshot.tracks.map((track) => track.effectsDisplayed);
+      if (!arraysEqual(state.effectsDisplayed, nextEffects)) {
+        nextState.effectsDisplayed = nextEffects;
+      }
+
+      const nextPanning = snapshot.tracks.map((track) => track.panning);
+      if (!arraysEqual(state.trackPanning, nextPanning)) {
+        nextState.trackPanning = nextPanning;
+      }
+
+      if (snapshot.playing && snapshot.newPattern !== null) {
+        if (
+          state.currentPattern.patternNo !== snapshot.patternNo ||
+          state.currentPattern.lines !== snapshot.newPattern
+        ) {
+          nextState.currentPattern = {
+            patternNo: snapshot.patternNo,
+            lines: snapshot.newPattern,
+          };
+        }
+      }
+
+      if (state.module.beatsPerMinute !== snapshot.currentBpm) {
+        nextState.module = {
+          ...state.module,
+          beatsPerMinute: snapshot.currentBpm,
+        };
+      }
+
+      if (Object.keys(nextState).length === 0) {
+        return state;
+      }
+
+      return nextState;
     }),
 }));


### PR DESCRIPTION
- Fixes a build failure from a clean git clone because of the .gitignore on CMakeLists.txt.
- Added stdint.h to heap.c, mix.c, and api_portaudio.c for GCC 15 to stop compile failure.
- Mismatch compiler error on effect_code array as a single integer.
- Rust cargo script update to dynamically link against Linux specific libraries.
